### PR TITLE
Use Linux `arm64` based runners for docker builds

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -34,7 +34,16 @@ permissions:
 jobs:
   docker:
     name: docker
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, ubuntu-24.04-arm]
+        platform: [linux/amd64, linux/arm64]
+        include:
+          - os: ubuntu-latest
+            platform: linux/amd64
+          - os: ubuntu-24.04-arm
+            platform: linux/arm64
 
     steps:
       - name: checkout
@@ -73,7 +82,7 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          platforms: linux/amd64,linux/arm64
+          platforms: ${{ matrix.platform }}
 
       - name: digest
         env:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -37,8 +37,6 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, ubuntu-24.04-arm]
-        platform: [linux/amd64, linux/arm64]
         include:
           - os: ubuntu-latest
             platform: linux/amd64


### PR DESCRIPTION
This pull request makes it so that docker builds in CI take place on their respective runner images (architecture). Now we can use the new [arm64](https://github.blog/changelog/2025-01-16-linux-arm64-hosted-runners-now-available-for-free-in-public-repositories-public-preview/) runners for faster builds on arm platforms.