### PR TITLE
Deployment id fixes

### DIFF
--- a/acceptance/logs/expected.log
+++ b/acceptance/logs/expected.log
@@ -3,7 +3,7 @@ INFO: 📖 loading runway configuration
 DEBUG: attempting to load config from acceptance/config/config.yml
 INFO: ✅ loaded configuration successfully
 INFO: 🚚 2 projects loaded
-INFO: 🛫 starting runway - version: v0.5.1
+INFO: 🛫 starting runway - version: v0.5.2
 INFO: 📦 starting project project-1
 INFO: 🕐 scheduling event with interval 3s for project-1
 INFO: 📦 starting project project-2

--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: runway
-version: 0.5.0
+version: 0.5.2
 
 authors:
   - GrantBirki

--- a/src/runway/events/github_deployment.cr
+++ b/src/runway/events/github_deployment.cr
@@ -157,7 +157,7 @@ class GitHubDeployment < BaseEvent
     # the first deployment to have an "in_progress" status will be the one we're looking for
     # however, the "in_progress" status must be the most recent status for the deployment or we'll ignore it
     deployments.each do |deployment|
-      deployment_id = deployment.id.to_i32
+      deployment_id = deployment.id
       statuses = @github.list_deployment_statuses(@event.repo.not_nil!, deployment_id, per_page: 100)
       statuses = statuses.records
 

--- a/src/runway/services/github.cr
+++ b/src/runway/services/github.cr
@@ -23,7 +23,7 @@ module Runway
       end
     end
 
-    def list_deployment_statuses(repo : String, deployment_id : Int32, per_page : Int32 = 30) : Octokit::Connection::Paginator(Octokit::Models::DeploymentStatus)
+    def list_deployment_statuses(repo : String, deployment_id : Int64, per_page : Int32 = 30) : Octokit::Connection::Paginator(Octokit::Models::DeploymentStatus)
       Retriable.retry do
         check_rate_limit!
         @client.list_deployment_statuses(repo, deployment_id, per_page: per_page)

--- a/src/version.cr
+++ b/src/version.cr
@@ -1,3 +1,3 @@
 module Runway
-  VERSION = "v0.5.1"
+  VERSION = "v0.5.2"
 end


### PR DESCRIPTION
The GitHub deployment ID should always be an `Int64`. This PR also bumps the version to `v0.5.2`.