### PR TITLE
add a log message at the start of deployments

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: runway
-version: 0.5.5
+version: 0.5.7
 
 authors:
   - GrantBirki

--- a/src/runway/models/project.cr
+++ b/src/runway/models/project.cr
@@ -51,6 +51,7 @@ class Project
     # Check if the desired event type had a deployable event occur
     payload = @events[event.uuid].check_for_event
     @log.debug { "deployment event triggered from event.type #{event.type} for #{@name} - event.uuid #{event.uuid}" } if payload.ship_it?
+    @log.info { Emoji.emojize(":astronaut: deploying #{@name}#{payload.environment ? " to #{payload.environment}" : ""}!") } if payload.ship_it?
 
     # If the event was triggered, run the project's deployment configuration
     payload = @deployment.deploy(payload).not_nil! if payload.ship_it?

--- a/src/version.cr
+++ b/src/version.cr
@@ -1,3 +1,3 @@
 module Runway
-  VERSION = "v0.5.6"
+  VERSION = "v0.5.7"
 end


### PR DESCRIPTION
This pull request introduces a simple new log message to show when a deployment starts for a given `Project`.